### PR TITLE
#port-1x-s3trait-methods Port setPublicPermissions, listFilesWithUrls, listFiles from 1.x

### DIFF
--- a/src/Util/S3Trait.php
+++ b/src/Util/S3Trait.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
  */
 namespace CakeDC\Uppy\Util;
 
+use Aws\Exception\AwsException;
 use Aws\S3\S3Client;
 use Aws\S3\Transfer;
 use Cake\Core\Configure;
@@ -232,5 +233,89 @@ trait S3Trait
         }
 
         throw new Exception('Folder doesn\'t exist. Please try again.');
+    }
+
+    /**
+     * Set public-read ACL on an existing S3 object.
+     *
+     * @param string $key S3 object key.
+     * @return void
+     */
+    public function setPublicPermissions(string $key): void
+    {
+        $s3Client = $this->getS3Client();
+        $s3Client->putObjectAcl([
+            'Bucket' => Configure::readOrFail('Uppy.S3.bucket'),
+            'Key' => $key,
+            'ACL' => 'public-read',
+        ]);
+    }
+
+    /**
+     * List files in the S3 bucket and generate a presigned GET URL for each.
+     *
+     * @param string $prefix Optional folder path or prefix to filter files.
+     * @param int $maxKeys Maximum number of files to return.
+     * @return array<array<string,mixed>> List of objects including 'Key', 'Size', and 'presigned_url'.
+     * @throws \Exception
+     */
+    public function listFilesWithUrls(string $prefix = '', int $maxKeys = 1000): array
+    {
+        $s3Client = $this->getS3Client();
+
+        $options = [
+            'Bucket' => Configure::readOrFail('Uppy.S3.bucket'),
+            'MaxKeys' => $maxKeys,
+        ];
+
+        if (!empty($prefix)) {
+            $options['Prefix'] = $prefix;
+        }
+
+        try {
+            $result = $s3Client->listObjectsV2($options);
+            $objects = $result->get('Contents') ?? [];
+
+            return array_map(function (array $object): array {
+                $object['presigned_url'] = $this->presignedUrl(
+                    $object['Key'],
+                    basename($object['Key']),
+                );
+
+                return $object;
+            }, $objects);
+        } catch (AwsException $e) {
+            throw new Exception('Error listing files with URLs from S3: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * List files in the S3 bucket, optionally filtered by a prefix.
+     *
+     * @param string $prefix Optional folder path or prefix to filter files.
+     * @param int $maxKeys Maximum number of files to return.
+     * @return array<array<string,mixed>> List of objects containing 'Key', 'LastModified', 'Size', etc.
+     * @throws \Exception
+     */
+    public function listFiles(string $prefix = '', int $maxKeys = 1000): array
+    {
+        $s3Client = $this->getS3Client();
+
+        $options = [
+            'Bucket' => Configure::readOrFail('Uppy.S3.bucket'),
+            'MaxKeys' => $maxKeys,
+        ];
+
+        if (!empty($prefix)) {
+            $options['Prefix'] = $prefix;
+        }
+
+        try {
+            $result = $s3Client->listObjectsV2($options);
+
+            return $result->get('Contents') ?? [];
+        } catch (AwsException $e) {
+            throw new Exception('Error listing files from S3: ' . $e->getMessage());
+        }
     }
 }

--- a/tests/TestCase/Util/S3TraitTest.php
+++ b/tests/TestCase/Util/S3TraitTest.php
@@ -1,0 +1,375 @@
+<?php
+declare(strict_types=1);
+
+namespace CakeDC\Uppy\Test\TestCase\Util;
+
+use Aws\Exception\AwsException;
+use Aws\Result;
+use Aws\S3\S3Client;
+use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
+use CakeDC\Uppy\Util\S3Trait;
+use Exception;
+
+class S3TraitTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Configure::write('Uppy.S3', [
+            'constants' => [
+                'lifeTimeGetObject' => '+20 minutes',
+                'lifeTimePutObject' => '+5 minutes',
+            ],
+            'config' => [
+                'version' => 'latest',
+                'region' => 'us-east-1',
+                'connection' => 'dummy',
+                'credentials' => ['key' => 'fake', 'secret' => 'fake'],
+            ],
+            'bucket' => 'test-bucket',
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        Configure::delete('Uppy.S3');
+        parent::tearDown();
+    }
+
+    // ── setPublicPermissions ──────────────────────────────────────────────────
+
+    public function testSetPublicPermissionsCallsPutObjectAclWithCorrectParams(): void
+    {
+        $mockClient = $this->getMockBuilder(S3Client::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['putObjectAcl'])
+            ->getMock();
+        $mockClient->expects($this->once())
+            ->method('putObjectAcl')
+            ->with([
+                'Bucket' => 'test-bucket',
+                'Key' => 'path/to/file.jpg',
+                'ACL' => 'public-read',
+            ])
+            ->willReturn(new Result([]));
+
+        $subject = new class ($mockClient) {
+            use S3Trait;
+
+            public function __construct(private readonly S3Client $injectedClient)
+            {
+            }
+
+            protected function getS3Client(): S3Client
+            {
+                return $this->injectedClient;
+            }
+        };
+
+        $subject->setPublicPermissions('path/to/file.jpg');
+        $this->assertTrue(true); // no exception thrown
+    }
+
+    // ── listFilesWithUrls ─────────────────────────────────────────────────────
+
+    public function testListFilesWithUrlsReturnsObjectsWithPresignedUrls(): void
+    {
+        $mockClient = $this->getMockBuilder(S3Client::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['listObjectsV2'])
+            ->getMock();
+        $mockClient->method('listObjectsV2')->willReturn(new Result([
+            'Contents' => [
+                ['Key' => 'folder/file.jpg', 'Size' => 1024],
+                ['Key' => 'folder/other.png', 'Size' => 2048],
+            ],
+        ]));
+
+        $subject = new class ($mockClient) {
+            use S3Trait;
+
+            public function __construct(private readonly S3Client $injectedClient)
+            {
+            }
+
+            protected function getS3Client(): S3Client
+            {
+                return $this->injectedClient;
+            }
+        };
+
+        // dummy connection → presignedUrl() returns 'https://example.com' without real AWS call
+        $result = $subject->listFilesWithUrls();
+        $this->assertCount(2, $result);
+        $this->assertSame('folder/file.jpg', $result[0]['Key']);
+        $this->assertArrayHasKey('presigned_url', $result[0]);
+        $this->assertSame('https://example.com', $result[0]['presigned_url']);
+        $this->assertArrayHasKey('presigned_url', $result[1]);
+    }
+
+    public function testListFilesWithUrlsReturnsEmptyArrayWhenNoContents(): void
+    {
+        $mockClient = $this->getMockBuilder(S3Client::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['listObjectsV2'])
+            ->getMock();
+        $mockClient->method('listObjectsV2')->willReturn(new Result(['Contents' => null]));
+
+        $subject = new class ($mockClient) {
+            use S3Trait;
+
+            public function __construct(private readonly S3Client $injectedClient)
+            {
+            }
+
+            protected function getS3Client(): S3Client
+            {
+                return $this->injectedClient;
+            }
+        };
+
+        $this->assertSame([], $subject->listFilesWithUrls());
+    }
+
+    public function testListFilesWithUrlsPassesPrefixAndMaxKeys(): void
+    {
+        $mockClient = $this->getMockBuilder(S3Client::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['listObjectsV2'])
+            ->getMock();
+        $mockClient->expects($this->once())
+            ->method('listObjectsV2')
+            ->with([
+                'Bucket' => 'test-bucket',
+                'MaxKeys' => 50,
+                'Prefix' => 'uploads/',
+            ])
+            ->willReturn(new Result(['Contents' => null]));
+
+        $subject = new class ($mockClient) {
+            use S3Trait;
+
+            public function __construct(private readonly S3Client $injectedClient)
+            {
+            }
+
+            protected function getS3Client(): S3Client
+            {
+                return $this->injectedClient;
+            }
+        };
+
+        $subject->listFilesWithUrls('uploads/', 50);
+        $this->assertTrue(true);
+    }
+
+    public function testListFilesWithUrlsOmitsPrefixWhenEmpty(): void
+    {
+        $mockClient = $this->getMockBuilder(S3Client::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['listObjectsV2'])
+            ->getMock();
+        $mockClient->expects($this->once())
+            ->method('listObjectsV2')
+            ->with([
+                'Bucket' => 'test-bucket',
+                'MaxKeys' => 1000,
+            ])
+            ->willReturn(new Result(['Contents' => null]));
+
+        $subject = new class ($mockClient) {
+            use S3Trait;
+
+            public function __construct(private readonly S3Client $injectedClient)
+            {
+            }
+
+            protected function getS3Client(): S3Client
+            {
+                return $this->injectedClient;
+            }
+        };
+
+        $subject->listFilesWithUrls();
+        $this->assertTrue(true);
+    }
+
+    public function testListFilesWithUrlsThrowsOnAwsException(): void
+    {
+        $mockException = $this->getMockBuilder(AwsException::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockClient = $this->getMockBuilder(S3Client::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['listObjectsV2'])
+            ->getMock();
+        $mockClient->method('listObjectsV2')->willThrowException($mockException);
+
+        $subject = new class ($mockClient) {
+            use S3Trait;
+
+            public function __construct(private readonly S3Client $injectedClient)
+            {
+            }
+
+            protected function getS3Client(): S3Client
+            {
+                return $this->injectedClient;
+            }
+        };
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Error listing files with URLs from S3:');
+        $subject->listFilesWithUrls();
+    }
+
+    // ── listFiles ─────────────────────────────────────────────────────────────
+
+    public function testListFilesReturnsContents(): void
+    {
+        $files = [
+            ['Key' => 'folder/a.jpg', 'Size' => 512],
+            ['Key' => 'folder/b.png', 'Size' => 1024],
+        ];
+
+        $mockClient = $this->getMockBuilder(S3Client::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['listObjectsV2'])
+            ->getMock();
+        $mockClient->method('listObjectsV2')->willReturn(new Result(['Contents' => $files]));
+
+        $subject = new class ($mockClient) {
+            use S3Trait;
+
+            public function __construct(private readonly S3Client $injectedClient)
+            {
+            }
+
+            protected function getS3Client(): S3Client
+            {
+                return $this->injectedClient;
+            }
+        };
+
+        $this->assertSame($files, $subject->listFiles());
+    }
+
+    public function testListFilesReturnsEmptyArrayWhenNoContents(): void
+    {
+        $mockClient = $this->getMockBuilder(S3Client::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['listObjectsV2'])
+            ->getMock();
+        $mockClient->method('listObjectsV2')->willReturn(new Result(['Contents' => null]));
+
+        $subject = new class ($mockClient) {
+            use S3Trait;
+
+            public function __construct(private readonly S3Client $injectedClient)
+            {
+            }
+
+            protected function getS3Client(): S3Client
+            {
+                return $this->injectedClient;
+            }
+        };
+
+        $this->assertSame([], $subject->listFiles());
+    }
+
+    public function testListFilesPassesPrefixAndMaxKeys(): void
+    {
+        $mockClient = $this->getMockBuilder(S3Client::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['listObjectsV2'])
+            ->getMock();
+        $mockClient->expects($this->once())
+            ->method('listObjectsV2')
+            ->with([
+                'Bucket' => 'test-bucket',
+                'MaxKeys' => 100,
+                'Prefix' => 'archive/',
+            ])
+            ->willReturn(new Result(['Contents' => null]));
+
+        $subject = new class ($mockClient) {
+            use S3Trait;
+
+            public function __construct(private readonly S3Client $injectedClient)
+            {
+            }
+
+            protected function getS3Client(): S3Client
+            {
+                return $this->injectedClient;
+            }
+        };
+
+        $subject->listFiles('archive/', 100);
+        $this->assertTrue(true);
+    }
+
+    public function testListFilesOmitsPrefixWhenEmpty(): void
+    {
+        $mockClient = $this->getMockBuilder(S3Client::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['listObjectsV2'])
+            ->getMock();
+        $mockClient->expects($this->once())
+            ->method('listObjectsV2')
+            ->with([
+                'Bucket' => 'test-bucket',
+                'MaxKeys' => 1000,
+            ])
+            ->willReturn(new Result(['Contents' => null]));
+
+        $subject = new class ($mockClient) {
+            use S3Trait;
+
+            public function __construct(private readonly S3Client $injectedClient)
+            {
+            }
+
+            protected function getS3Client(): S3Client
+            {
+                return $this->injectedClient;
+            }
+        };
+
+        $subject->listFiles();
+        $this->assertTrue(true);
+    }
+
+    public function testListFilesThrowsOnAwsException(): void
+    {
+        $mockException = $this->getMockBuilder(AwsException::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mockClient = $this->getMockBuilder(S3Client::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['listObjectsV2'])
+            ->getMock();
+        $mockClient->method('listObjectsV2')->willThrowException($mockException);
+
+        $subject = new class ($mockClient) {
+            use S3Trait;
+
+            public function __construct(private readonly S3Client $injectedClient)
+            {
+            }
+
+            protected function getS3Client(): S3Client
+            {
+                return $this->injectedClient;
+            }
+        };
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Error listing files from S3:');
+        $subject->listFiles();
+    }
+}


### PR DESCRIPTION
## Summary

Ports three S3Trait methods present in the `1.next-cake4` branch (PRs #5 and #7) but missing from `2.next-cake5`:

- `setPublicPermissions(string $key)` — sets `public-read` ACL on an S3 object
- `listFilesWithUrls(string $prefix, int $maxKeys)` — lists objects and appends a presigned GET URL to each
- `listFiles(string $prefix, int $maxKeys)` — lists objects filtered by prefix

Methods are adapted to the `2.next` conventions: use `getS3Client()`, `Configure::readOrFail()`, and typed closures. `AwsException` is caught and re-thrown as a plain `Exception` with a descriptive message.

## Test Plan

- [ ] `vendor/bin/phpunit tests/TestCase/Util/S3TraitTest.php --no-coverage` — 11 tests, 22 assertions, all green
- [ ] `vendor/bin/phpcs src/Util/S3Trait.php tests/TestCase/Util/S3TraitTest.php` — no violations