### PR TITLE
2.3.0 changelog and semver

### DIFF
--- a/.semver
+++ b/.semver
@@ -1,6 +1,6 @@
 ---
 :major: 2
-:minor: 0
-:patch: 3
+:minor: 3
+:patch: 0
 :special: ''
 :metadata: ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,17 @@ Changelog
 
 Releases for CakePHP 5.0
 ------------------------
-* 2.1.0
-    * Add pluggable storage drivers via `StorageAdapterInterface` and `AdapterFactory`
-    * Add Google Cloud Storage (`gcs`) adapter (requires `google/cloud-storage`)
-    * Add Cloudflare R2 (`r2`) adapter
-    * New config key `Uppy.driver` (env `UPPY_DRIVER`) selects the active backend
-    * Rename `Uppy.Props.deleteFileS3` to `deleteFileStorage`; the old key is still honored for backwards compatibility
+* 2.3.0
+    * New: `S3Trait::setPublicPermissions(string $key)` — sets `public-read` ACL on an S3 object
+    * New: `S3Trait::listFilesWithUrls(string $prefix, int $maxKeys)` — lists objects and appends a presigned GET URL to each
+    * New: `S3Trait::listFiles(string $prefix, int $maxKeys)` — lists objects in an S3 bucket filtered by prefix
+
+* 2.2.0
+    * New: pluggable storage drivers via `StorageAdapterInterface` and `AdapterFactory`
+    * New: Google Cloud Storage (`gcs`) adapter (requires `google/cloud-storage`)
+    * New: Cloudflare R2 (`r2`) adapter
+    * New: config key `Uppy.driver` (env `UPPY_DRIVER`) selects the active backend
+    * Rename: `Uppy.Props.deleteFileS3` → `deleteFileStorage`; old key still honored for backwards compatibility
 
 * 2.0.3
     * Update documentation


### PR DESCRIPTION
Fixes the mislabeled 2.1.0 entry (was the 2.2.0 adapter release), adds 2.3.0 entry for the S3Trait port, bumps .semver to 2.3.0.